### PR TITLE
fetch pr head before merge

### DIFF
--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -7,7 +7,12 @@ phases:
     runtime-versions:
       nodejs: 14
     commands:
-      - if [ ! -z "${COMMIT_ID}" ]; then git checkout main; git merge --no-edit ${COMMIT_ID}; fi
+      - |
+        if [ ! -z "${COMMIT_ID}" ]; then 
+          git fetch origin pull/${PR_NUMBER}/head:pr
+          git checkout main
+          git merge --no-edit ${COMMIT_ID}
+        fi
       - | 
         npm install aws-cdk@1.113.0 -g
         npm install


### PR DESCRIPTION
When a pr is made from a fork, e2e tests currently fail as the commit id from the fork is not in the upstream tree.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
