### PR TITLE
Feature/manifests to teams

### DIFF
--- a/docs/teams.md
+++ b/docs/teams.md
@@ -6,7 +6,7 @@ You are also able to create your own team implementations by creating classes th
 
 ### ApplicationTeam 
 
-To create an `ApplicationTeam` for your cluster, simply implement a class that extends `ApplicationTeam`. You will need to supply a team name, an array of users, and (optionally) a directory where you may optionally place any policy definitions and generic manifests for the team. These manifests will be applied by the platform and will be outside of the team control **NOTE:** The files are not checked for accuracy, and you must ensure, for example, that the namespace provided match the actual namespace. 
+To create an `ApplicationTeam` for your cluster, simply implement a class that extends `ApplicationTeam`. You will need to supply a team name, an array of users, and (optionally) a directory where you may optionally place any policy definitions and generic manifests for the team. These manifests will be applied by the platform and will be outside of the team control **NOTE:** When the manifests are applied, namespaces are not checked. Therefore, you are responsible for namespace settings in the yaml files.
 
 ```typescript
 export class TeamAwesome extends ApplicationTeam {
@@ -17,7 +17,7 @@ export class TeamAwesome extends ApplicationTeam {
                 new ArnPrincipal(`arn:aws:iam::${YOUR_IAM_ACCOUNT}:user/user1`),  
                 new ArnPrincipal(`arn:aws:iam::${YOUR_IAM_ACCOUNT}:user/user2`)
             ]
-        manifestDir: './examples/teams/team-awesome/'
+        teamManifestDir: './examples/teams/team-awesome/'
         });
     }
 }

--- a/docs/teams.md
+++ b/docs/teams.md
@@ -6,7 +6,7 @@ You are also able to create your own team implementations by creating classes th
 
 ### ApplicationTeam 
 
-To create an `ApplicationTeam` for your cluster, simplye implement a class that extends `ApplicationTeam`. You will need to supply a team name and an array of users.  
+To create an `ApplicationTeam` for your cluster, simply implement a class that extends `ApplicationTeam`. You will need to supply a team name, an array of users, and (optionally) a directory where you may optionally place any policy definitions and generic manifests for the team. These manifests will be applied by the platform and will be outside of the team control **NOTE:** The files are not checked for accuracy, and you must ensure, for example, that the namespace provided match the actual namespace. 
 
 ```typescript
 export class TeamAwesome extends ApplicationTeam {
@@ -17,7 +17,7 @@ export class TeamAwesome extends ApplicationTeam {
                 new ArnPrincipal(`arn:aws:iam::${YOUR_IAM_ACCOUNT}:user/user1`),  
                 new ArnPrincipal(`arn:aws:iam::${YOUR_IAM_ACCOUNT}:user/user2`)
             ]
-
+        manifestDir: './examples/teams/team-awesome/'
         });
     }
 }
@@ -30,6 +30,7 @@ The `ApplicationTeam` will do the following:
 - Register IAM users for cross-account access
 - Create a shared role for cluster access. Alternatively, an existing role can be supplied.
 - Register provided users/role in the `awsAuth` map for `kubectl` and console access to the cluster and namespace.
+- (Optionally) read all additional manifests (e.g., network policies, OPA policies, others) stored in a provided directory, and applies them.
 
 ### PlatformTeam 
 

--- a/examples/blueprint-construct/index.ts
+++ b/examples/blueprint-construct/index.ts
@@ -7,6 +7,10 @@ import * as ssp from '../../lib'
 // Example teams.
 import * as team from '../teams'
 
+const burnhamManifestDir = './examples/teams/team-burnham/'
+const rikerManifestDir = './examples/teams/team-riker/'
+const teamManifestDirList = [burnhamManifestDir,rikerManifestDir]
+
 export interface BlueprintConstructProps {
     /**
      * Id
@@ -30,8 +34,8 @@ export default class BlueprintConstruct extends cdk.Construct {
         // Teams for the cluster.
         const teams: Array<ssp.Team> = [
             new team.TeamTroi,
-            new team.TeamRiker,
-            new team.TeamBurnham(scope)
+            new team.TeamRiker(scope, teamManifestDirList[1]),
+            new team.TeamBurnham(scope, teamManifestDirList[0])
         ];
         const prodBootstrapArgo = new ssp.addons.ArgoCDAddOn({
             bootstrapRepo: {

--- a/examples/teams/team-burnham/index.ts
+++ b/examples/teams/team-burnham/index.ts
@@ -13,7 +13,7 @@ function getUserArns(scope: Construct, key: string): ArnPrincipal[] {
 }
 
 export class TeamBurnham extends ApplicationTeam {
-    constructor(scope: Construct) {
+    constructor(scope: Construct, teamManifestDir: string) {
         super({
             name: "burnham",
             users: getUserArns(scope, "team-burnham.users"),
@@ -29,7 +29,8 @@ export class TeamBurnham extends ApplicationTeam {
                         ]
                     }
                 }
-            ]
+            ],
+            teamManifestDir: teamManifestDir
         });
     }
 }

--- a/examples/teams/team-burnham/restrict-ingress-egress-burnham.yaml
+++ b/examples/teams/team-burnham/restrict-ingress-egress-burnham.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: restrict-ingress-egress-burnham
+  namespace: team-burnham
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: team-riker
+    ports:
+    - protocol: TCP
+      port: 80
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          name: team-troi
+    ports:
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 53

--- a/examples/teams/team-riker/index.ts
+++ b/examples/teams/team-riker/index.ts
@@ -1,14 +1,22 @@
-import { ClusterInfo, Team } from '../../../lib';
+import { ArnPrincipal } from '@aws-cdk/aws-iam';
+import { Construct } from '@aws-cdk/core';
 
-export class TeamRiker implements Team {
+import { ApplicationTeam } from '../../../lib/teams';
 
-    readonly name = 'team-riker';
+function getUserArns(scope: Construct, key: string): ArnPrincipal[] {
+    const context: string = scope.node.tryGetContext(key);
+    if (context) {
+        return context.split(",").map(e => new ArnPrincipal(e));
+    }
+    return [];
+}
 
-    setup(clusterInfo: ClusterInfo) {
-        clusterInfo.cluster.addManifest(this.name, {
-            apiVersion: 'v1',
-            kind: 'Namespace',
-            metadata: { name: 'team-riker' }
+export class TeamRiker extends ApplicationTeam {
+    constructor(scope: Construct, teamManifestDir: string) {
+        super({
+            name: "riker",
+            users: getUserArns(scope, "team-riker.users"),
+            teamManifestDir: teamManifestDir
         });
     }
 }

--- a/examples/teams/team-riker/restrict-ingress-egress-riker.yaml
+++ b/examples/teams/team-riker/restrict-ingress-egress-riker.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: restrict-ingress-egress-riker
+  namespace: team-riker
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: team-troi
+    ports:
+    - protocol: TCP
+      port: 80
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          name: team-burnham
+    ports:
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 53

--- a/lib/teams/index.ts
+++ b/lib/teams/index.ts
@@ -59,7 +59,7 @@ export class TeamProps {
     readonly teamSecrets?: TeamSecretsProps[];
 
     /**
-     * Optional, directory where a team's network policy files are stored
+     * Optional, directory where a team's manifests are stored
      */
      readonly teamManifestDir?: string;
 }
@@ -210,6 +210,7 @@ export class ApplicationTeam implements Team {
         });
 
         rbacManifest.node.addDependency(this.namespaceManifest);
+
         if (teamManifestDir){
             applyYamlFromDir(teamManifestDir, clusterInfo.cluster, this.namespaceManifest)
         }

--- a/lib/utils/yaml-utils.ts
+++ b/lib/utils/yaml-utils.ts
@@ -4,6 +4,13 @@ import * as eks from '@aws-cdk/aws-eks';
 import request from 'sync-request';
 import { KubernetesManifest } from '@aws-cdk/aws-eks';
 
+/**
+ * Applies all manifests from a directory. Note: The manifests are not checked, 
+ * so user must ensure the manifests have the correct namespaces. 
+ * @param dir 
+ * @param cluster 
+ * @param namespaceManifest 
+ */
 export function applyYamlFromDir(dir: string, cluster: eks.Cluster, namespaceManifest: KubernetesManifest): void {
     fs.readdir(dir, 'utf8', (err, files) => {
         if (files != undefined) {

--- a/lib/utils/yaml-utils.ts
+++ b/lib/utils/yaml-utils.ts
@@ -2,8 +2,9 @@ import * as fs from 'fs';
 import * as yaml from 'js-yaml';
 import * as eks from '@aws-cdk/aws-eks';
 import request from 'sync-request';
+import { KubernetesManifest } from '@aws-cdk/aws-eks';
 
-export function readYamlFromDir(dir: string, cluster: eks.Cluster): void {
+export function applyYamlFromDir(dir: string, cluster: eks.Cluster, namespaceManifest: KubernetesManifest): void {
     fs.readdir(dir, 'utf8', (err, files) => {
         if (files != undefined) {
             files.forEach((file) => {
@@ -12,7 +13,8 @@ export function readYamlFromDir(dir: string, cluster: eks.Cluster): void {
                         if (data != undefined) {
                             let i = 0;
                             yaml.loadAll(data).forEach((item) => {
-                                cluster.addManifest(file.substr(0, file.length - 5) + i, item);
+                                const resources = cluster.addManifest(file.substr(0, file.length - 5) + i, item);
+                                resources.node.addDependency(namespaceManifest)
                                 i++;
                             })
                         }


### PR DESCRIPTION
*Issue #, if available:* 31

*Description of changes:*

Description of changes: Add feature to apply network policies team-wise at the creation of ApplicationTeams. This PR will replace the previous PR closed due to rebasing conflict: https://github.com/aws-quickstart/ssp-amazon-eks/pull/146. This PR has addressed all comments under the previous PR.

Changes include:

- Changes in main.ts, and the following changes under example templates: team-riker/index.ts, team-burnham/index.ts blueprint-construct/index.ts
- Example policy manifests added to individual team folders under example templates for: team-riker, team-burnham
- Doc updates on usage and expectation that users must ensure manifests have the correct namespaces.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
