### PR TITLE
Fix/183 external dns nginx deployment order

### DIFF
--- a/examples/blueprint-construct/index.ts
+++ b/examples/blueprint-construct/index.ts
@@ -47,14 +47,14 @@ export default class BlueprintConstruct extends cdk.Construct {
         const addOns: Array<ssp.ClusterAddOn> = [
             new ssp.addons.AppMeshAddOn(),
             prodBootstrapArgo,
-            new ssp.addons.NginxAddOn(),
             new ssp.addons.CalicoAddOn(),
             new ssp.addons.MetricsServerAddOn(),
             new ssp.addons.ClusterAutoScalerAddOn(),
             new ssp.addons.ContainerInsightsAddOn(),
             new ssp.addons.AwsLoadBalancerControllerAddOn(),
             new ssp.addons.SecretsStoreAddOn(),
-            new ssp.addons.SSMAgentAddOn()
+            new ssp.addons.SSMAgentAddOn(),
+            new ssp.addons.NginxAddOn()
         ];
 
         const blueprintID = `${blueprintProps.id}-dev`

--- a/lib/addons/argocd/index.ts
+++ b/lib/addons/argocd/index.ts
@@ -4,9 +4,8 @@ import { HelmChart, KubernetesManifest, ServiceAccount } from "@aws-cdk/aws-eks"
 import { ManagedPolicy } from "@aws-cdk/aws-iam";
 
 import * as spi from "../../spi";
-import { getSecretValue } from '../../utils/secrets-manager-utils';
+import { getSecretValue, btoa } from '../../utils';
 import { sshRepoRef, userNameRepoRef } from './manifest-utils';
-import { btoa } from '../../utils/string-utils';
 import { Constants } from "..";
 
 /**

--- a/lib/addons/aws-loadbalancer-controller/index.ts
+++ b/lib/addons/aws-loadbalancer-controller/index.ts
@@ -2,6 +2,7 @@ import * as cdk from "@aws-cdk/core";
 import * as iam from "@aws-cdk/aws-iam";
 import request from 'sync-request';
 import { ClusterAddOn, ClusterInfo } from "../../spi";
+import { Construct } from "@aws-cdk/core";
 
 /**
  * Configuration options for the add-on.
@@ -61,7 +62,7 @@ export class AwsLoadBalancerControllerAddOn implements ClusterAddOn {
         this.options = { ...defaultProps, ...props };
     }
 
-    deploy(clusterInfo: ClusterInfo): void {
+    deploy(clusterInfo: ClusterInfo): Promise<Construct> {
         const cluster = clusterInfo.cluster;
         const serviceAccount = cluster.addServiceAccount('aws-load-balancer-controller', {
             name: AWS_LOAD_BALANCER_CONTROLLER,
@@ -99,5 +100,7 @@ export class AwsLoadBalancerControllerAddOn implements ClusterAddOn {
         });
 
         awsLoadBalancerControllerChart.node.addDependency(serviceAccount);
+        // return the Promise Construct for any teams that may depend on this
+        return Promise.resolve(awsLoadBalancerControllerChart);
     }
 }

--- a/lib/addons/aws-loadbalancer-controller/index.ts
+++ b/lib/addons/aws-loadbalancer-controller/index.ts
@@ -1,6 +1,6 @@
 import * as cdk from "@aws-cdk/core";
 import * as iam from "@aws-cdk/aws-iam";
-import request from 'sync-request';
+import request from "sync-request";
 import { ClusterAddOn, ClusterInfo } from "../../spi";
 import { Construct } from "@aws-cdk/core";
 

--- a/lib/addons/external-dns/index.ts
+++ b/lib/addons/external-dns/index.ts
@@ -1,5 +1,6 @@
 import { KubernetesManifest } from '@aws-cdk/aws-eks';
 import { Effect, PolicyStatement } from '@aws-cdk/aws-iam';
+import { Construct } from '@aws-cdk/core';
 import { Constants } from '..';
 
 import { ClusterAddOn, ClusterInfo } from '../../spi';
@@ -40,7 +41,7 @@ export class ExternalDnsAddon implements ClusterAddOn {
         this.options = props
     }
 
-    deploy(clusterInfo: ClusterInfo): void {
+    deploy(clusterInfo: ClusterInfo): Promise<Construct> {
         const region = clusterInfo.cluster.stack.region;
         const cluster = clusterInfo.cluster;
         const namespace = this.options.namespace ?? this.name;
@@ -97,5 +98,7 @@ export class ExternalDnsAddon implements ClusterAddOn {
         });
 
         chart.node.addDependency(namespaceManifest);
+        // return the Promise Construct for any teams that may depend on this
+        return Promise.resolve(chart);
     }
 }

--- a/lib/addons/nginx/index.ts
+++ b/lib/addons/nginx/index.ts
@@ -81,12 +81,12 @@ export class NginxAddOn implements ClusterAddOn {
         const props = this.options;
 
         const dependencies = Array<Promise<Construct>>();
-        const awsLoadBalancerControllerAddOnPromise = clusterInfo.getpreProvisionedAddOn('AwsLoadBalancerControllerAddOn');
+        const awsLoadBalancerControllerAddOnPromise = clusterInfo.getScheduledAddOn('AwsLoadBalancerControllerAddOn');
         console.assert(awsLoadBalancerControllerAddOnPromise, 'NginxAddOn has a dependency on AwsLoadBalancerControllerAddOn');
         dependencies.push(awsLoadBalancerControllerAddOnPromise!);
 
         if (props.externalDnsHostname) {
-            const externalDnsAddOnPromise = clusterInfo.getpreProvisionedAddOn('ExternalDnsAddon');
+            const externalDnsAddOnPromise = clusterInfo.getScheduledAddOn('ExternalDnsAddon');
             console.assert(externalDnsAddOnPromise, 'NginxAddOn has a dependency on ExternalDnsAddOn');
             dependencies.push(externalDnsAddOnPromise!);
         }

--- a/lib/addons/nginx/index.ts
+++ b/lib/addons/nginx/index.ts
@@ -118,11 +118,10 @@ export class NginxAddOn implements ClusterAddOn {
             values
         });
 
-        const asyncTasks = Promise.all(dependencies.values()).then((constructs) => {
+        Promise.all(dependencies.values()).then((constructs) => {
             constructs.forEach((construct) => {
                 nginxHelmChart.node.addDependency(construct);
             });
-        });
-        asyncTasks.catch(err => { throw new Error(err) });
+        }).catch(err => { throw new Error(err) });
     }
 }

--- a/lib/addons/nginx/index.ts
+++ b/lib/addons/nginx/index.ts
@@ -1,3 +1,4 @@
+import { Construct } from "@aws-cdk/core";
 import { Constants } from "..";
 import { ClusterAddOn, ClusterInfo } from "../../spi";
 
@@ -79,6 +80,17 @@ export class NginxAddOn implements ClusterAddOn {
 
         const props = this.options;
 
+        const dependencies = Array<Promise<Construct>>();
+        const awsLoadBalancerControllerAddOnPromise = clusterInfo.getpreProvisionedAddOn('AwsLoadBalancerControllerAddOn');
+        console.assert(awsLoadBalancerControllerAddOnPromise, 'NginxAddOn has a dependency on AwsLoadBalancerControllerAddOn');
+        dependencies.push(awsLoadBalancerControllerAddOnPromise!);
+
+        if (props.externalDnsHostname) {
+            const externalDnsAddOnPromise = clusterInfo.getpreProvisionedAddOn('ExternalDnsAddon');
+            console.assert(externalDnsAddOnPromise, 'NginxAddOn has a dependency on ExternalDnsAddOn');
+            dependencies.push(externalDnsAddOnPromise!);
+        }
+
         const presetAnnotations = {
             'service.beta.kubernetes.io/aws-load-balancer-backend-protocol': props.backendProtocol,
             'service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled': `${props.crossZoneEnabled}`,
@@ -97,7 +109,7 @@ export class NginxAddOn implements ClusterAddOn {
             }
         };
 
-        clusterInfo.cluster.addHelmChart("nginx-addon", {
+        const nginxHelmChart = clusterInfo.cluster.addHelmChart("nginx-addon", {
             chart: "nginx-ingress",
             repository: "https://helm.nginx.com/stable",
             release: Constants.SSP_ADDON,
@@ -105,5 +117,12 @@ export class NginxAddOn implements ClusterAddOn {
             version: props.version,
             values
         });
+        
+        const asyncTasks = Promise.all(dependencies.values()).then((constructs) => {
+            constructs.forEach((construct) => {
+                nginxHelmChart.node.addDependency(construct);
+            });
+        });
+        asyncTasks.catch(err => { throw new Error(err) });
     }
 }

--- a/lib/addons/nginx/index.ts
+++ b/lib/addons/nginx/index.ts
@@ -117,7 +117,7 @@ export class NginxAddOn implements ClusterAddOn {
             version: props.version,
             values
         });
-        
+
         const asyncTasks = Promise.all(dependencies.values()).then((constructs) => {
             constructs.forEach((construct) => {
                 nginxHelmChart.node.addDependency(construct);

--- a/lib/addons/xray/index.ts
+++ b/lib/addons/xray/index.ts
@@ -3,8 +3,7 @@ import { ManagedPolicy } from "@aws-cdk/aws-iam";
 
 import { assertEC2NodeGroup } from "../../cluster-providers";
 import { ClusterAddOn, ClusterInfo } from "../../spi";
-import { loadYaml, readYamlDocument } from "../../utils/yaml-utils";
-import { createNamespace } from "../../utils/namespace-utils"
+import { loadYaml, readYamlDocument, createNamespace } from "../../utils";
 
 /**
  * Implementation of AWS X-Ray add-on for EKS SSP. Installs xray daemonset and exposes 

--- a/lib/spi/types.ts
+++ b/lib/spi/types.ts
@@ -53,7 +53,7 @@ export class ClusterInfo {
     readonly nodeGroup?: Nodegroup;
     readonly autoScalingGroup?: AutoScalingGroup;
     private readonly provisionedAddOns: Map<string, cdk.Construct>;
-    private readonly preProvisionedAddOns: Map<string, Promise<cdk.Construct>>;
+    private readonly scheduledAddOns: Map<string, Promise<cdk.Construct>>;
 
     /**
      * Constructor for ClusterInfo
@@ -71,7 +71,7 @@ export class ClusterInfo {
             }
         }
         this.provisionedAddOns = new Map<string, cdk.Construct>();
-        this.preProvisionedAddOns = new Map<string, Promise<cdk.Construct>>();
+        this.scheduledAddOns = new Map<string, Promise<cdk.Construct>>();
     }
 
     /**
@@ -103,8 +103,8 @@ export class ClusterInfo {
      * @param addOn
      * @param promise
      */
-     public addPreProvisionedAddOn(addOn: string, promise: Promise<cdk.Construct>) {
-        this.preProvisionedAddOns.set(addOn, promise);
+     public addScheduledAddOn(addOn: string, promise: Promise<cdk.Construct>) {
+        this.scheduledAddOns.set(addOn, promise);
     }
 
     /**
@@ -112,7 +112,7 @@ export class ClusterInfo {
      * @param addOn
      * @returns Promise<cdk.Construct>
      */
-    public getPreProvisionedAddOn(addOn: string): Promise<cdk.Construct> | undefined {
-        return this.preProvisionedAddOns.get(addOn);
+    public getScheduledAddOn(addOn: string): Promise<cdk.Construct> | undefined {
+        return this.scheduledAddOns.get(addOn);
     }
 }

--- a/lib/spi/types.ts
+++ b/lib/spi/types.ts
@@ -53,6 +53,7 @@ export class ClusterInfo {
     readonly nodeGroup?: Nodegroup;
     readonly autoScalingGroup?: AutoScalingGroup;
     private readonly provisionedAddOns: Map<string, cdk.Construct>;
+    private readonly preProvisionedAddOns: Map<string, Promise<cdk.Construct>>;
 
     /**
      * Constructor for ClusterInfo
@@ -70,6 +71,7 @@ export class ClusterInfo {
             }
         }
         this.provisionedAddOns = new Map<string, cdk.Construct>();
+        this.preProvisionedAddOns = new Map<string, Promise<cdk.Construct>>();
     }
 
     /**
@@ -93,5 +95,24 @@ export class ClusterInfo {
         else {
             return undefined;
         }
+    }
+
+    /**
+     * Set the preProvisionedAddOn map with the promise for the construct 
+     * of the addon being provisioned 
+     * @param addOn 
+     * @param promise 
+     */
+     public addpreProvisionedAddOn(addOn: string, promise: Promise<cdk.Construct>) {
+        this.preProvisionedAddOns.set(addOn, promise);
+    }
+    
+    /**
+     * Returns the promise for the Addon construct
+     * @param addOn
+     * @returns Promise<cdk.Construct>
+     */
+    public getpreProvisionedAddOn(addOn: string): Promise<cdk.Construct> | undefined {
+        return this.preProvisionedAddOns.get(addOn);
     }
 }

--- a/lib/spi/types.ts
+++ b/lib/spi/types.ts
@@ -98,15 +98,15 @@ export class ClusterInfo {
     }
 
     /**
-     * Set the preProvisionedAddOn map with the promise for the construct 
-     * of the addon being provisioned 
-     * @param addOn 
-     * @param promise 
+     * Set the preProvisionedAddOn map with the promise for the construct
+     * of the addon being provisioned
+     * @param addOn
+     * @param promise
      */
      public addpreProvisionedAddOn(addOn: string, promise: Promise<cdk.Construct>) {
         this.preProvisionedAddOns.set(addOn, promise);
     }
-    
+
     /**
      * Returns the promise for the Addon construct
      * @param addOn

--- a/lib/spi/types.ts
+++ b/lib/spi/types.ts
@@ -115,4 +115,12 @@ export class ClusterInfo {
     public getScheduledAddOn(addOn: string): Promise<cdk.Construct> | undefined {
         return this.scheduledAddOns.get(addOn);
     }
+
+    /**
+     * Returns all scheduled addons
+     * @returns scheduledAddOns: Map<string, Promise<cdk.Construct>>
+     */
+    public getAllScheduledAddons(): Map<string, Promise<cdk.Construct>> {
+        return this.scheduledAddOns;
+    }
 }

--- a/lib/spi/types.ts
+++ b/lib/spi/types.ts
@@ -103,7 +103,7 @@ export class ClusterInfo {
      * @param addOn
      * @param promise
      */
-     public addpreProvisionedAddOn(addOn: string, promise: Promise<cdk.Construct>) {
+     public addPreProvisionedAddOn(addOn: string, promise: Promise<cdk.Construct>) {
         this.preProvisionedAddOns.set(addOn, promise);
     }
 
@@ -112,7 +112,7 @@ export class ClusterInfo {
      * @param addOn
      * @returns Promise<cdk.Construct>
      */
-    public getpreProvisionedAddOn(addOn: string): Promise<cdk.Construct> | undefined {
+    public getPreProvisionedAddOn(addOn: string): Promise<cdk.Construct> | undefined {
         return this.preProvisionedAddOns.get(addOn);
     }
 }

--- a/lib/stacks/eks-blueprint-stack.ts
+++ b/lib/stacks/eks-blueprint-stack.ts
@@ -167,7 +167,7 @@ export class EksBlueprint extends cdk.Stack {
                 const addOnKey = this.getAddOnNameorId(addOn);
                 promises.push(result);
                 addOnKeys.push(addOnKey);
-                this.clusterInfo.addPreProvisionedAddOn(addOnKey, result);
+                this.clusterInfo.addScheduledAddOn(addOnKey, result);
             }
             const postDeploy: any = addOn;
             if ((postDeploy as spi.ClusterPostDeploy).postDeploy !== undefined) {

--- a/lib/stacks/eks-blueprint-stack.ts
+++ b/lib/stacks/eks-blueprint-stack.ts
@@ -6,7 +6,7 @@ import { IVpc, Vpc } from '@aws-cdk/aws-ec2';
 import { KubernetesVersion } from '@aws-cdk/aws-eks';
 import { MngClusterProvider } from '../cluster-providers/mng-cluster-provider';
 import * as spi from '../spi';
-import { withUsageTracking } from '../utils/usage-utils';
+import { withUsageTracking, getAddOnNameOrId } from '../utils';
 
 export class EksBlueprintProps {
 
@@ -162,7 +162,7 @@ export class EksBlueprint extends cdk.Stack {
         for (let addOn of (blueprintProps.addOns ?? [])) { // must iterate in the strict order
             const result = addOn.deploy(this.clusterInfo);
             if (result) {
-                const addOnKey = this.getAddOnNameorId(addOn);
+                const addOnKey = getAddOnNameOrId(addOn);
                 this.clusterInfo.addScheduledAddOn(addOnKey, result);
             }
             const postDeploy: any = addOn;
@@ -251,14 +251,5 @@ export class EksBlueprint extends cdk.Stack {
         }
 
         return vpc;
-    }
-
-    /**
-     * Returns AddOn Id if defined else returns the class name
-     * @param addOn 
-     * @returns 
-     */
-    private getAddOnNameorId(addOn: spi.ClusterAddOn): string {
-        return addOn.id ?? addOn.constructor.name;
     }
 }

--- a/lib/stacks/eks-blueprint-stack.ts
+++ b/lib/stacks/eks-blueprint-stack.ts
@@ -167,7 +167,7 @@ export class EksBlueprint extends cdk.Stack {
                 const addOnKey = this.getAddOnNameorId(addOn);
                 promises.push(result);
                 addOnKeys.push(addOnKey);
-                this.clusterInfo.addpreProvisionedAddOn(addOnKey, result);
+                this.clusterInfo.addPreProvisionedAddOn(addOnKey, result);
             }
             const postDeploy: any = addOn;
             if ((postDeploy as spi.ClusterPostDeploy).postDeploy !== undefined) {

--- a/lib/stacks/eks-blueprint-stack.ts
+++ b/lib/stacks/eks-blueprint-stack.ts
@@ -164,8 +164,10 @@ export class EksBlueprint extends cdk.Stack {
         for (let addOn of (blueprintProps.addOns ?? [])) { // must iterate in the strict order
             const result = addOn.deploy(this.clusterInfo);
             if (result) {
+                const addOnKey = this.getAddOnNameorId(addOn);
                 promises.push(result);
-                addOnKeys.push(addOn.id ?? addOn.constructor.name);
+                addOnKeys.push(addOnKey);
+                this.clusterInfo.addpreProvisionedAddOn(addOnKey, result);
             }
             const postDeploy: any = addOn;
             if ((postDeploy as spi.ClusterPostDeploy).postDeploy !== undefined) {
@@ -248,5 +250,9 @@ export class EksBlueprint extends cdk.Stack {
         }
 
         return vpc;
+    }
+
+    private getAddOnNameorId(addOn: spi.ClusterAddOn) {
+        return addOn.id ?? addOn.constructor.name;
     }
 }

--- a/lib/stacks/eks-blueprint-stack.ts
+++ b/lib/stacks/eks-blueprint-stack.ts
@@ -252,7 +252,12 @@ export class EksBlueprint extends cdk.Stack {
         return vpc;
     }
 
-    private getAddOnNameorId(addOn: spi.ClusterAddOn) {
+    /**
+     * Returns AddOn Id if defined else returns the class name
+     * @param addOn 
+     * @returns 
+     */
+    private getAddOnNameorId(addOn: spi.ClusterAddOn): string {
         return addOn.id ?? addOn.constructor.name;
     }
 }

--- a/lib/utils/addon-utils.ts
+++ b/lib/utils/addon-utils.ts
@@ -1,0 +1,11 @@
+
+import { ClusterAddOn } from '../spi';
+
+/**
+ * Returns AddOn Id if defined else returns the class name
+ * @param addOn
+ * @returns string
+ */
+export function getAddOnNameOrId(addOn: ClusterAddOn): string {
+  return addOn.id ?? addOn.constructor.name;
+}

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,0 +1,7 @@
+export * from './addon-utils';
+export * from './context-utils';
+export * from './namespace-utils';
+export * from './secrets-manager-utils';
+export * from './string-utils';
+export * from './usage-utils';
+export * from './yaml-utils';

--- a/test/stacks.test.ts
+++ b/test/stacks.test.ts
@@ -29,6 +29,7 @@ test('Blueprint builder creates correct stack', async () => {
 
     blueprint.account("123567891").region('us-west-1')
         .addons(new ssp.ArgoCDAddOn)
+        .addons(new ssp.AwsLoadBalancerControllerAddOn)
         .addons(new ssp.NginxAddOn)
         .teams(new ssp.PlatformTeam({ name: 'platform' }));
 
@@ -59,6 +60,7 @@ test('Pipeline Builder Creates correct pipeline', () => {
         .account("123567891")
         .region('us-west-1')
         .addons(new ssp.ArgoCDAddOn)
+        .addons(new ssp.AwsLoadBalancerControllerAddOn)
         .addons(new ssp.NginxAddOn)
         .teams(new ssp.PlatformTeam({ name: 'platform' }));
 


### PR DESCRIPTION
*Issue #, if available:* #183

*Description of changes:*
Adds a mechanism for handling inter addon dependencies such as between nginx and external-load-balancer add on. Now addons can depend on the promise of construct from the addon that its dependent on. The dependent addon can then wait for promise to be fulfilled and create its dependency as shown in the nginx example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
