### PR TITLE
refactor for decorator pattern for handling inter-addon dependencies

### DIFF
--- a/lib/addons/nginx/index.ts
+++ b/lib/addons/nginx/index.ts
@@ -77,7 +77,7 @@ export class NginxAddOn implements ClusterAddOn {
         this.options = { ...defaultProps, ...props };
     }
 
-    @dependable(['AwsLoadBalancerControllerAddOn'])
+    @dependable('AwsLoadBalancerControllerAddOn')
     deploy(clusterInfo: ClusterInfo): Promise<Construct> {
 
         const props = this.options;

--- a/lib/utils/addon-utils.ts
+++ b/lib/utils/addon-utils.ts
@@ -1,5 +1,6 @@
 
-import { ClusterAddOn } from '../spi';
+import { Construct } from '@aws-cdk/core';
+import { ClusterAddOn, ClusterInfo } from '../spi';
 
 /**
  * Returns AddOn Id if defined else returns the class name
@@ -8,4 +9,36 @@ import { ClusterAddOn } from '../spi';
  */
 export function getAddOnNameOrId(addOn: ClusterAddOn): string {
   return addOn.id ?? addOn.constructor.name;
+}
+
+export function dependable(addOns: Array<string>) {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  return function (target: Object, key: string | symbol, descriptor: PropertyDescriptor) {
+    const original = descriptor.value;
+
+    descriptor.value = function( ...args: any[]) {
+      const dependencies = Array<Promise<Construct>>();
+      const clusterInfo: ClusterInfo = args[0];
+
+      addOns.forEach( (addOn) => {
+        const dep = clusterInfo.getScheduledAddOn(addOn);
+        console.assert(dep, `Missing dependency for ${addOn}`);
+        dependencies.push(dep!);
+      });
+
+      const result: Promise<Construct> = original.apply(this, args);
+
+      Promise.all(dependencies.values()).then((constructs) => {
+        constructs.forEach((construct) => {
+            result.then((resource) => {
+              resource.node.addDependency(construct);
+            });
+        });
+      }).catch(err => { throw new Error(err) });
+
+      return result;
+    };
+
+    return descriptor;
+  };
 }

--- a/lib/utils/addon-utils.ts
+++ b/lib/utils/addon-utils.ts
@@ -18,7 +18,7 @@ export function getAddOnNameOrId(addOn: ClusterAddOn): string {
  * @param addOns 
  * @returns 
  */
-export function dependable(addOns: Array<string>) {
+export function dependable(...addOns: string[]) {
   // eslint-disable-next-line @typescript-eslint/ban-types
   return function (target: Object, key: string | symbol, descriptor: PropertyDescriptor) {
     const originalMethod = descriptor.value;

--- a/lib/utils/addon-utils.ts
+++ b/lib/utils/addon-utils.ts
@@ -11,22 +11,30 @@ export function getAddOnNameOrId(addOn: ClusterAddOn): string {
   return addOn.id ?? addOn.constructor.name;
 }
 
+/**
+ * Decorator function that accepts a list of AddOns and
+ * ensures addons are scheduled to be added as well as
+ * add them as dependencies
+ * @param addOns 
+ * @returns 
+ */
 export function dependable(addOns: Array<string>) {
   // eslint-disable-next-line @typescript-eslint/ban-types
   return function (target: Object, key: string | symbol, descriptor: PropertyDescriptor) {
-    const original = descriptor.value;
+    const originalMethod = descriptor.value;
 
     descriptor.value = function( ...args: any[]) {
       const dependencies = Array<Promise<Construct>>();
       const clusterInfo: ClusterInfo = args[0];
+      const stack = clusterInfo.cluster.stack.stackName;
 
       addOns.forEach( (addOn) => {
         const dep = clusterInfo.getScheduledAddOn(addOn);
-        console.assert(dep, `Missing dependency for ${addOn}`);
+        console.assert(dep, `Missing a dependency for ${addOn} for ${stack}`);
         dependencies.push(dep!);
       });
 
-      const result: Promise<Construct> = original.apply(this, args);
+      const result: Promise<Construct> = originalMethod.apply(this, args);
 
       Promise.all(dependencies.values()).then((constructs) => {
         constructs.forEach((construct) => {

--- a/test/stacks.test.ts
+++ b/test/stacks.test.ts
@@ -1,114 +1,141 @@
 import { expect as expectCDK, haveResourceLike } from '@aws-cdk/assert';
 import * as cdk from '@aws-cdk/core';
 import * as ssp from '../lib';
-import { NestedStackAddOn } from '../lib';
+import { NestedStackAddOn, NginxAddOn } from '../lib';
 import { MyVpcStack } from './test-support';
 
-test('Usage tracking created', () => {
-    const app = new cdk.App();
-    // WHEN
-    let stack = new ssp.EksBlueprint(app, { id: 'MyTestStack' });
-    console.log(stack.templateOptions.description);
-    // THEN
-    assertBlueprint(stack);
+const consoleSpy = jest.spyOn(console, 'assert').mockImplementation();
 
-    stack = new ssp.EksBlueprint(app, { id: 'MyOtherTestStack' }, {
-        description: "My awesome description"
+describe('Unit tests for EKS Blueprint', () => {
+
+    beforeEach(() => {
+        consoleSpy.mockClear();
     });
 
-    console.log(stack.templateOptions.description);
-    // AND
-    assertBlueprint(stack);
+    test('Usage tracking created', () => {
+        const app = new cdk.App();
+        // WHEN
+        let stack = new ssp.EksBlueprint(app, { id: 'MyTestStack' });
+        console.log(stack.templateOptions.description);
+        // THEN
+        assertBlueprint(stack);
 
-});
-
-test('Blueprint builder creates correct stack', async () => {
-    const app = new cdk.App();
-
-    const blueprint = ssp.EksBlueprint.builder();
-
-    blueprint.account("123567891").region('us-west-1')
-        .addons(new ssp.ArgoCDAddOn)
-        .addons(new ssp.AwsLoadBalancerControllerAddOn)
-        .addons(new ssp.NginxAddOn)
-        .teams(new ssp.PlatformTeam({ name: 'platform' }));
-
-    const stack1 = await blueprint.buildAsync(app, "stack-1");
-
-    assertBlueprint(stack1, 'nginx-ingress', 'argo-cd');
-
-    const blueprint2 = blueprint.clone('us-west-2', '1234567891').addons(new ssp.CalicoAddOn);
-    const stack2 = await blueprint2.buildAsync(app, 'stack-2');
-
-    assertBlueprint(stack2, 'nginx-ingress', 'argo-cd', 'aws-calico');
-
-    const blueprint3 = ssp.EksBlueprint.builder().withBlueprintProps({
-        addOns: [new ssp.ArgoCDAddOn],
-        name: 'my-blueprint3',
-        id: 'my-blueprint3-id'
-    });
-
-    const stack3 = await blueprint3.buildAsync(app, 'stack-3');
-    assertBlueprint(stack3, 'argo-cd');
-});
-
-test('Pipeline Builder Creates correct pipeline', () => {
-
-    const app = new cdk.App();
-
-    const blueprint = ssp.EksBlueprint.builder()
-        .account("123567891")
-        .region('us-west-1')
-        .addons(new ssp.ArgoCDAddOn)
-        .addons(new ssp.AwsLoadBalancerControllerAddOn)
-        .addons(new ssp.NginxAddOn)
-        .teams(new ssp.PlatformTeam({ name: 'platform' }));
-
-    const pipeline = ssp.CodePipelineStack.builder()
-        .name("ssp-pipeline-inaction")
-        .owner('shapirov103')
-        .repository({
-            repoUrl: 'git@github',
-            credentialsSecretName: 'github-token',
-            name: 'my-iac-pipeline'
-        })
-        .stage({
-            id: 'us-east-1-ssp',
-            stackBuilder: blueprint.clone('us-east-1'),
-        })
-        .stage({
-            id: 'us-east-2-ssp',
-            stackBuilder: blueprint.clone('us-east-2')
-        })
-        .stage({
-            id: 'prod-ssp',
-            stackBuilder: blueprint.clone('us-west-2'),
-            stageProps: { manualApprovals: true }
+        stack = new ssp.EksBlueprint(app, { id: 'MyOtherTestStack' }, {
+            description: "My awesome description"
         });
 
-    const stack = pipeline.build(app, "ssp-pipeline-id");
-    console.log(stack.templateOptions.description);
-    expect(stack.templateOptions.description).toContain("SSP tracking (qs");
-});
+        console.log(stack.templateOptions.description);
+        // AND
+        assertBlueprint(stack);
 
-test("Nested stack add-on creates correct nested stack", async () => {
-    const app = new cdk.App();
-
-    const vpcAddOn = new NestedStackAddOn( {
-        builder: MyVpcStack.builder(),
-        id: "vpc-nested-stack"
     });
-    
-    const blueprint = ssp.EksBlueprint.builder();
 
-    blueprint.account("123567891").region('us-west-1')
-        .addons(vpcAddOn)
-        .teams(new ssp.PlatformTeam({ name: 'platform' }));
+    test("Stack creation fails due to missing add-on dependency", () => {
+        const app = new cdk.App();
 
-    const parentStack =  await blueprint.buildAsync(app, "stack-with-nested");
-    const clusterInfo = parentStack.getClusterInfo();
-    expect(clusterInfo.getProvisionedAddOn("vpc-nested-stack")).toBeDefined();
-    
+        const blueprint = ssp.EksBlueprint.builder();
+
+        blueprint.account("123567891").region('us-west-1')
+            .addons(new NginxAddOn)
+            .teams(new ssp.PlatformTeam({ name: 'platform' }));
+
+        blueprint.build(app, 'stack-with-missing-deps');
+
+        expect(console.assert).toBeCalledTimes(1);
+        expect(console.assert).toHaveBeenCalledWith(
+            undefined,
+            'Missing a dependency for AwsLoadBalancerControllerAddOn for stack-with-missing-deps'
+        );
+    });
+
+    test('Blueprint builder creates correct stack', async () => {
+        const app = new cdk.App();
+
+        const blueprint = ssp.EksBlueprint.builder();
+
+        blueprint.account("123567891").region('us-west-1')
+            .addons(new ssp.ArgoCDAddOn)
+            .addons(new ssp.AwsLoadBalancerControllerAddOn)
+            .addons(new ssp.NginxAddOn)
+            .teams(new ssp.PlatformTeam({ name: 'platform' }));
+
+        const stack1 = await blueprint.buildAsync(app, "stack-1");
+
+        assertBlueprint(stack1, 'nginx-ingress', 'argo-cd');
+
+        const blueprint2 = blueprint.clone('us-west-2', '1234567891').addons(new ssp.CalicoAddOn);
+        const stack2 = await blueprint2.buildAsync(app, 'stack-2');
+
+        assertBlueprint(stack2, 'nginx-ingress', 'argo-cd', 'aws-calico');
+
+        const blueprint3 = ssp.EksBlueprint.builder().withBlueprintProps({
+            addOns: [new ssp.ArgoCDAddOn],
+            name: 'my-blueprint3',
+            id: 'my-blueprint3-id'
+        });
+
+        const stack3 = await blueprint3.buildAsync(app, 'stack-3');
+        assertBlueprint(stack3, 'argo-cd');
+    });
+
+    test('Pipeline Builder Creates correct pipeline', () => {
+
+        const app = new cdk.App();
+
+        const blueprint = ssp.EksBlueprint.builder()
+            .account("123567891")
+            .region('us-west-1')
+            .addons(new ssp.ArgoCDAddOn)
+            .addons(new ssp.AwsLoadBalancerControllerAddOn)
+            .addons(new ssp.NginxAddOn)
+            .teams(new ssp.PlatformTeam({ name: 'platform' }));
+
+        const pipeline = ssp.CodePipelineStack.builder()
+            .name("ssp-pipeline-inaction")
+            .owner('shapirov103')
+            .repository({
+                repoUrl: 'git@github',
+                credentialsSecretName: 'github-token',
+                name: 'my-iac-pipeline'
+            })
+            .stage({
+                id: 'us-east-1-ssp',
+                stackBuilder: blueprint.clone('us-east-1'),
+            })
+            .stage({
+                id: 'us-east-2-ssp',
+                stackBuilder: blueprint.clone('us-east-2')
+            })
+            .stage({
+                id: 'prod-ssp',
+                stackBuilder: blueprint.clone('us-west-2'),
+                stageProps: { manualApprovals: true }
+            });
+
+        const stack = pipeline.build(app, "ssp-pipeline-id");
+        console.log(stack.templateOptions.description);
+        expect(stack.templateOptions.description).toContain("SSP tracking (qs");
+    });
+
+    test("Nested stack add-on creates correct nested stack", async () => {
+        const app = new cdk.App();
+
+        const vpcAddOn = new NestedStackAddOn( {
+            builder: MyVpcStack.builder(),
+            id: "vpc-nested-stack"
+        });
+
+        const blueprint = ssp.EksBlueprint.builder();
+
+        blueprint.account("123567891").region('us-west-1')
+            .addons(vpcAddOn)
+            .teams(new ssp.PlatformTeam({ name: 'platform' }));
+
+        const parentStack =  await blueprint.buildAsync(app, "stack-with-nested");
+        const clusterInfo = parentStack.getClusterInfo();
+        expect(clusterInfo.getProvisionedAddOn("vpc-nested-stack")).toBeDefined();
+
+    });
 });
 
 function assertBlueprint(stack: ssp.EksBlueprint, ...charts: string[]) {

--- a/test/stacks.test.ts
+++ b/test/stacks.test.ts
@@ -40,8 +40,7 @@ describe('Unit tests for EKS Blueprint', () => {
 
         blueprint.build(app, 'stack-with-missing-deps');
 
-        expect(console.assert).toBeCalledTimes(1);
-        expect(console.assert).toHaveBeenCalledWith(
+        expect(console.assert).toHaveBeenLastCalledWith(
             undefined,
             'Missing a dependency for AwsLoadBalancerControllerAddOn for stack-with-missing-deps'
         );

--- a/test/stacks.test.ts
+++ b/test/stacks.test.ts
@@ -1,7 +1,6 @@
 import { expect as expectCDK, haveResourceLike } from '@aws-cdk/assert';
 import * as cdk from '@aws-cdk/core';
 import * as ssp from '../lib';
-import { NestedStackAddOn, NginxAddOn } from '../lib';
 import { MyVpcStack } from './test-support';
 
 const consoleSpy = jest.spyOn(console, 'assert').mockImplementation();
@@ -36,7 +35,7 @@ describe('Unit tests for EKS Blueprint', () => {
         const blueprint = ssp.EksBlueprint.builder();
 
         blueprint.account("123567891").region('us-west-1')
-            .addons(new NginxAddOn)
+            .addons(new ssp.NginxAddOn)
             .teams(new ssp.PlatformTeam({ name: 'platform' }));
 
         blueprint.build(app, 'stack-with-missing-deps');
@@ -120,7 +119,7 @@ describe('Unit tests for EKS Blueprint', () => {
     test("Nested stack add-on creates correct nested stack", async () => {
         const app = new cdk.App();
 
-        const vpcAddOn = new NestedStackAddOn( {
+        const vpcAddOn = new ssp.NestedStackAddOn( {
             builder: MyVpcStack.builder(),
             id: "vpc-nested-stack"
         });

--- a/test/stacks.test.ts
+++ b/test/stacks.test.ts
@@ -61,6 +61,7 @@ describe('Unit tests for EKS Blueprint', () => {
         const stack1 = await blueprint.buildAsync(app, "stack-1");
 
         assertBlueprint(stack1, 'nginx-ingress', 'argo-cd');
+        expect(console.assert).toHaveBeenLastCalledWith(true);
 
         const blueprint2 = blueprint.clone('us-west-2', '1234567891').addons(new ssp.CalicoAddOn);
         const stack2 = await blueprint2.buildAsync(app, 'stack-2');
@@ -133,7 +134,6 @@ describe('Unit tests for EKS Blueprint', () => {
         const parentStack =  await blueprint.buildAsync(app, "stack-with-nested");
         const clusterInfo = parentStack.getClusterInfo();
         expect(clusterInfo.getProvisionedAddOn("vpc-nested-stack")).toBeDefined();
-
     });
 });
 
@@ -146,4 +146,3 @@ function assertBlueprint(stack: ssp.EksBlueprint, ...charts: string[]) {
 
     expect(stack.templateOptions.description).toContain("SSP tracking (qs");
 }
-


### PR DESCRIPTION
*Issue #, if available:* #197

*Description of changes:*
Adding a new `@dependable([list of AddOns])` decorator to handle addon dependencies to remove the repeatable code for asserting an dependent addon is scheduled as well as create resource dependencies in the cloudformation resources.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
