### PR TITLE
docfix: use team-riker namespace argo dev example

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -209,10 +209,10 @@ argocd app sync dev-apps
 
 ### Validate deployments. 
 
-To validate your deployments, leverage `kubectl port-forwarding` to access the `guestbook-ui` service for `team-burnham`.
+To validate your deployments, leverage `kubectl port-forwarding` to access the `guestbook-ui` service for `team-riker`.
 
 ```
-kubectl port-forward svc/guestbook-ui -n team-burnham 4040:80
+kubectl port-forward svc/guestbook-ui -n team-riker 4040:80
 ```
 
 Open up `localhost:4040` in your browser and you should see the application.


### PR DESCRIPTION
*Issue #, if available:*
argocd getting-started example using team-burnham namesapce to port-forward the guestbook-ui, the guestbook-ui svc is currently deployed under team-riker team.
Relevant PR - https://github.com/aws-samples/ssp-eks-workloads/pull/4
*Description of changes:*
doc fix to use the right team and namespace 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
