### PR TITLE
Cluster Autoscaler hotfix

### DIFF
--- a/lib/addons/cluster-autoscaler/index.ts
+++ b/lib/addons/cluster-autoscaler/index.ts
@@ -70,6 +70,7 @@ export class ClusterAutoScalerAddOn extends HelmAddOn {
             "autoscaling:DescribeTags",
             "autoscaling:SetDesiredCapacity",
             "autoscaling:TerminateInstanceInAutoScalingGroup",
+            "ec2:DescribeInstanceTypes",
             "ec2:DescribeLaunchTemplateVersions"
         );
         const autoscalerPolicy = new iam.Policy(cluster.stack, "cluster-autoscaler-policy", {
@@ -87,7 +88,7 @@ export class ClusterAutoScalerAddOn extends HelmAddOn {
         this.addHelmChart(clusterInfo, {
             cloudProvider: 'aws',
             autoDiscovery: {
-                cluster: cluster.clusterName
+                clusterName: cluster.clusterName
             },
             awsRegion: clusterInfo.cluster.stack.region
         });


### PR DESCRIPTION
*Issue #, if available:* #253

*Description of changes:*
According to the helm chart documentation ([here](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#permissions) and [here](https://github.com/kubernetes/autoscaler/tree/master/charts/cluster-autoscaler#aws---using-auto-discovery-of-tagged-instance-groups)), couple of things were added/fixed to ensure the addon deploys correctly. Namely:

- Adding `"ec2:DescribeInstanceTypes"` in the IAM Policy
- Revising the chart value from `autoDiscovery.cluster` to `autodiscovery.clusterName`

Including the above two configuration items addressed the issue upon testing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
