### PR TITLE
addon-nginx-ingress: fixed path to httpsPort.targetPort and httpPort enabled

### DIFF
--- a/lib/addons/nginx/index.ts
+++ b/lib/addons/nginx/index.ts
@@ -96,8 +96,8 @@ export class NginxAddOn extends HelmAddOn {
             presetAnnotations['service.beta.kubernetes.io/aws-load-balancer-ssl-ports'] = 'https';
             const certificate = clusterInfo.getResource<ICertificate>(props.certificateResourceName);
             presetAnnotations['service.beta.kubernetes.io/aws-load-balancer-ssl-cert'] =  certificate?.certificateArn;
-            setPath(values, "controller.service.https.port.targetPort", "http");
-            setPath(values, "controller.service.http.port.enable", "false");
+            setPath(values, "controller.service.httpsPort.targetPort", "http");
+            setPath(values, "controller.service.httpPort.enable", "false");
         }
 
         const serviceAnnotations = { ...values.controller?.service?.annotations, ...presetAnnotations };


### PR DESCRIPTION
Signed-off-by: Thomas Schuetz <thomas.schuetz@dynatrace.com>

*Description of changes:*
* Changed the path of Helm Values to httpsPort.targetPort and httpPort.enabled, when a Certificate Name is set according to the Helm Chart.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
