### PR TITLE
Updating opa gatekeeper documentation

### DIFF
--- a/docs/addons/opa-gatekeeper.md
+++ b/docs/addons/opa-gatekeeper.md
@@ -33,13 +33,12 @@ import * as ssp from '@aws-quickstart/ssp-amazon-eks';
 const app = new cdk.App();
 const account = <AWS_ACCOUNT_ID>;
 const region = <AWS_REGION>;
-const env: { account, region },
 
 const blueprint = ssp.EksBlueprint.builder()
   .account(account) 
   .region(region)
   .addOns( new ssp.addons.OpaGatekeeperAddOn() )
-  .teams().build(app, 'my-stack-name', {env});
+  .teams().build(app, 'my-stack-name');
 ```
 
 To validate that OPA Gatekeeper is running within your cluster run the following command:


### PR DESCRIPTION
Refresh of OPA Gatekeeper documentation:

1. Added usage section for adding gatekeeper to your blueprint 
2. Added section for key terminology
3. Used simpler example (all namespaces must be created with labels)
4. Added additional links for exploration 
