### PR TITLE
Feature/Allow creation of IngressClass for ALB

### DIFF
--- a/docs/addons/aws-load-balancer-controller.md
+++ b/docs/addons/aws-load-balancer-controller.md
@@ -38,7 +38,10 @@ aws-load-balancer-controller                               2/2     2            
 1. Adds proper IAM permissions and creates a Kubernetes service account with IRSA integration. 
 2. Allows configuration options such as enabling WAF and Shield. 
 3. Allows to replace the helm chart version if a specific version of the controller is needed.
-4. Supports [standard helm configuration options](./index.md#standard-helm-add-on-configuration-options).
+4. Creates an IngressClass associated with the AWS Load Balance Controller when the createIngressClassResource prop is set to true
+5. Supports [standard helm configuration options](./index.md#standard-helm-add-on-configuration-options).
+
+_Note_: An ingressClass must be created in the cluster, either using the createIngressClassResource prop or externally, to be able to create Ingresses associated with the AWS ALB.
 
 ## Creating a Load Balanced Service
 

--- a/lib/addons/aws-loadbalancer-controller/index.ts
+++ b/lib/addons/aws-loadbalancer-controller/index.ts
@@ -22,7 +22,18 @@ export interface AwsLoadBalancerControllerProps extends HelmAddOnUserProps {
     /**
      * Enable WAFV2 (must be false for CN partition)
      */
-    enableWafv2?: boolean
+    enableWafv2?: boolean,
+
+    /**
+     * Create the ingressClass to be used by the ALB controller
+     */
+    createIngressClassResource?: boolean
+
+    /**
+     * Name of ingressClass to the ALB controller will satisfy. If not provided
+     * the value will be defaulted to "alb"
+     */
+    ingressClass?: string
 }
 
 
@@ -37,10 +48,12 @@ const defaultProps: AwsLoadBalancerControllerProps = {
     chart: AWS_LOAD_BALANCER_CONTROLLER,
     repository: 'https://aws.github.io/eks-charts',
     release: AWS_LOAD_BALANCER_CONTROLLER,
-    version: '1.2.3',
+    version: '1.3.3',
     enableShield: false,
     enableWaf: false,
-    enableWafv2: false
+    enableWafv2: false,
+    createIngressClassResource: true,
+    ingressClass: "alb"
 };
 
 
@@ -74,6 +87,8 @@ export class AwsLoadBalancerControllerAddOn extends HelmAddOn {
             enableShield: this.options.enableShield,
             enableWaf: this.options.enableWaf,
             enableWafv2: this.options.enableWafv2,
+            createIngressClassResource: this.options.createIngressClassResource,
+            ingressClass: this.options.ingressClass
         });
 
         awsLoadBalancerControllerChart.node.addDependency(serviceAccount);


### PR DESCRIPTION
Modification of the existing AWS ALB add-on:
- Upgrade ALB version from 1.2.3 to 1.3.3 as the old version does not allow creating an IngressClass using the the Helm values. (See [issue 612](https://github.com/aws/eks-charts/pull/612) in the ALB repo)
- Added props to explicitly indicate to the user the creation of the ingressClass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
