### PR TITLE
Use correct helm repo for secret-store-csi-driver

### DIFF
--- a/lib/addons/secrets-store/index.ts
+++ b/lib/addons/secrets-store/index.ts
@@ -47,7 +47,7 @@ const defaultProps: SecretsStoreAddOnProps = {
     namespace: 'kube-system',
     version: 'v0.0.23',
     release: 'ssp-addon-secret-store-csi-driver',
-    repository: 'https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts',
+    repository: 'https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts',
     rotationPollInterval: undefined,
     syncSecrets: true,
 };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The repo URL used is not a valid chart repository, causing the following error:

> Error: looks like "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/main/charts" is not a valid chart repository or cannot be reached: failed to fetch https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/main/charts/index.yaml : 404 Not Found

I've updated the repo URL to the one given by the upstream projects documentation on installing via Helm:

https://secrets-store-csi-driver.sigs.k8s.io/getting-started/installation.html#deployment-using-helm

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
