### PR TITLE
fix: pass VPC ID for ALB controller

### DIFF
--- a/lib/addons/aws-loadbalancer-controller/index.ts
+++ b/lib/addons/aws-loadbalancer-controller/index.ts
@@ -91,8 +91,8 @@ export class AwsLoadBalancerControllerAddOn extends HelmAddOn {
             createIngressClassResource: this.options.createIngressClassResource,
             ingressClass: this.options.ingressClass,
             region: clusterInfo.cluster.stack.region,
-            image: {repository: repo}
-
+            image: { repository: repo },
+            vpcId: clusterInfo.cluster.vpc.vpcId,
         });
 
         awsLoadBalancerControllerChart.node.addDependency(serviceAccount);


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-quickstart/ssp-amazon-eks/issues/312

*Description of changes:*

Deploying ALB controller to EKS Fargate requires passing the VPC ID. It is better to pass VPC ID to the ALB controller chart, regardless it is EC2 or Fargate EKS, because EKS security best practice recommends to block the EC2 metadata service from EC2 nodes as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
