### PR TITLE
release prep for 0.12.13, lint fix

### DIFF
--- a/bin/main.ts
+++ b/bin/main.ts
@@ -1,6 +1,4 @@
 #!/usr/bin/env node
-import * as ec2 from '@aws-cdk/aws-ec2';
-// import { KubernetesVersion } from '@aws-cdk/aws-eks';
 import * as cdk from '@aws-cdk/core';
 import BlueprintConstruct from '../examples/blueprint-construct';
 

--- a/lib/addons/ebs-csi-driver/index.ts
+++ b/lib/addons/ebs-csi-driver/index.ts
@@ -1,4 +1,3 @@
-import { PolicyDocument } from "@aws-cdk/aws-iam";
 import { CoreAddOn } from "../core-addon";
 import { getEbsDriverPolicyDocument } from "./iam-policy";
 
@@ -19,7 +18,6 @@ export class EbsCsiDriverAddOn extends CoreAddOn {
         super({
             addOnName: defaultProps.addOnName,
             version: version ?? defaultProps.version,
-
             policyDocumentProvider: getEbsDriverPolicyDocument
         });
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws-quickstart/ssp-amazon-eks",
-    "version": "0.12.12",
+    "version": "0.12.13",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
AWS Load balancer controller did not work correctly with Fargate profiles when specified. VPC was not passed to the helm chart. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
