### PR TITLE
Update buildspec to use node v16

### DIFF
--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -5,7 +5,7 @@ env:
 phases:
   install:
     runtime-versions:
-      nodejs: 14
+      nodejs: 16
     commands:
       - |
         if [ ! -z "${COMMIT_ID}" ]; then 


### PR DESCRIPTION
Otherwise CDK 2 builds fail

*Issue #, if available:*
Related to CDK v2.0 and renaming

*Description of changes:*
Updated nodejs version in the CI spec to enable e2e tests for the PR

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
